### PR TITLE
WIP Add Rotation feature

### DIFF
--- a/Sources/Demo/EditorViewController.swift
+++ b/Sources/Demo/EditorViewController.swift
@@ -40,8 +40,16 @@ final class EditorViewController : UIViewController {
 
   @IBAction func didTapPresentButton() {
 
-    let controller = PixelEditViewController.init(image: UIImage(named: "large")!)
-    
+    let imageSource = StaticImageSource(source: UIImage(named: "large")!)
+
+    let previewSize = CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width)
+    let stack = EditingStack(source: imageSource, previewSize: previewSize)
+
+    let controller = PixelEditViewController(
+        editingStack: stack
+      )
+    controller.delegate = self
+        
     let nav = UINavigationController(rootViewController: controller)
     nav.modalPresentationStyle = .fullScreen
 
@@ -94,12 +102,21 @@ extension EditorViewController : UIImagePickerControllerDelegate, UINavigationCo
 extension EditorViewController : PixelEditViewControllerDelegate {
   
   func pixelEditViewController(_ controller: PixelEditViewController, didEndEditing editingStack: EditingStack) {
-    self.navigationController?.popToViewController(self, animated: true)
+    if controller.presentingViewController != nil {
+      self.navigationController?.dismiss(animated: true, completion: nil)
+    } else {
+      self.navigationController?.popToViewController(self, animated: true)
+    }
     let image = editingStack.makeRenderer().render(resolution: .full)
     self.imageView.image = image
   }
   
   func pixelEditViewControllerDidCancelEditing(in controller: PixelEditViewController) {
+    if controller.presentingViewController != nil {
+      self.navigationController?.dismiss(animated: true, completion: nil)
+    } else {
+      self.navigationController?.popToViewController(self, animated: true)
+    }
     self.navigationController?.popToViewController(self, animated: true)
   }
 }

--- a/Sources/PixelEditor/ImageViews/CropAndStraightenView.swift
+++ b/Sources/PixelEditor/ImageViews/CropAndStraightenView.swift
@@ -94,7 +94,7 @@ final class CropAndStraightenView : UIView {
     }
   }
 
-  private let imageView: ImageScrollView = {
+  let imageView: ImageScrollView = {
 
     let view = ImageScrollView()
     view.imageContentMode = .aspectFill

--- a/Sources/PixelEditor/ImageViews/ImagePreviewView.swift
+++ b/Sources/PixelEditor/ImageViews/ImagePreviewView.swift
@@ -60,7 +60,6 @@ final class ImagePreviewView : UIView {
     }
     
     originalImageView.isHidden = true
-    
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/Sources/PixelEditor/PixelEditViewController.swift
+++ b/Sources/PixelEditor/PixelEditViewController.swift
@@ -162,11 +162,13 @@ public final class PixelEditViewController : UIViewController {
           disableView.bottomAnchor.constraint(equalTo: controlContainerView.bottomAnchor),
         ])
         doneButton.isEnabled = false
+        rotateButton.isEnabled = false
       }
       if !newValue {
         loadingViews?.forEach { $0.removeFromSuperview() }
         loadingViews = nil
         doneButton.isEnabled = true
+        rotateButton.isEnabled = true
       }
     }
   }
@@ -467,7 +469,7 @@ public final class PixelEditViewController : UIViewController {
     switch mode {
     case .adjustment:
 
-      navigationItem.rightBarButtonItem = nil
+      navigationItem.rightBarButtonItems = [rotateButton]
       navigationItem.leftBarButtonItem = nil
 
       adjustmentView.isHidden = false
@@ -509,7 +511,7 @@ public final class PixelEditViewController : UIViewController {
     case .preview:
 
       navigationItem.setHidesBackButton(true, animated: false)
-      navigationItem.rightBarButtonItems = [doneButton, rotateButton]
+      navigationItem.rightBarButtonItems = [doneButton]
       navigationItem.leftBarButtonItem = cancelButton
       
       didReceive(action: .setTitle(""))

--- a/Sources/PixelEngine/EditingStack.swift
+++ b/Sources/PixelEngine/EditingStack.swift
@@ -194,9 +194,9 @@ open class EditingStack {
     }
   }
   
-  public func setRotation(angle: CGFloat) {
+  public func setAngle(angle: Double) {
     applyIfChanged {
-      $0.rotation = angle
+      $0.angle = angle
     }
   }
 
@@ -272,7 +272,7 @@ open class EditingStack {
 
     renderer.edit.modifiers = edit.makeFilters()
     
-    renderer.edit.rotation = edit.rotation
+    renderer.edit.angle = edit.angle
 
     return renderer
   }
@@ -391,7 +391,7 @@ extension EditingStack {
     public var cropRect: CGRect?
     public var blurredMaskPaths: [DrawnPathInRect] = []
     public var filters: Filters = .init()
-    public var rotation: CGFloat?
+    public var angle: Double = 0
     
     func makeFilters() -> [Filtering] {
       return filters.makeFilters()

--- a/Sources/PixelEngine/EditingStack.swift
+++ b/Sources/PixelEngine/EditingStack.swift
@@ -193,6 +193,12 @@ open class EditingStack {
       filters(&$0.filters)
     }
   }
+  
+  public func setRotation(angle: CGFloat) {
+    applyIfChanged {
+      $0.rotation = angle
+    }
+  }
 
   public func setAdjustment(cropRect: CGRect) {
 
@@ -265,6 +271,8 @@ open class EditingStack {
     ]
 
     renderer.edit.modifiers = edit.makeFilters()
+    
+    renderer.edit.rotation = edit.rotation
 
     return renderer
   }
@@ -382,9 +390,9 @@ extension EditingStack {
 
     public var cropRect: CGRect?
     public var blurredMaskPaths: [DrawnPathInRect] = []
-
     public var filters: Filters = .init()
-
+    public var rotation: CGFloat?
+    
     func makeFilters() -> [Filtering] {
       return filters.makeFilters()
     }

--- a/Sources/PixelEngine/Engine/ImageRenderer.swift
+++ b/Sources/PixelEngine/Engine/ImageRenderer.swift
@@ -33,6 +33,7 @@ public final class ImageRenderer {
     public var croppingRect: CGRect?
     public var modifiers: [Filtering] = []
     public var drawer: [GraphicsDrawing] = []
+    public var rotation: CGFloat?
   }
 
   private let cicontext = CIContext(options: [
@@ -52,6 +53,10 @@ public final class ImageRenderer {
     guard let targetImage = source.imageSource?.image else {
       preconditionFailure("Nothing to render")
     }
+    if let rotation = edit.rotation {
+        // rotation is necessary
+    }
+    
     let resultImage: CIImage = {
 
       let sourceImage: CIImage
@@ -70,9 +75,8 @@ public final class ImageRenderer {
       let result = edit.modifiers.reduce(sourceImage, { image, modifier in
         return modifier.apply(to: image, sourceImage: sourceImage)
       })
-
+      
       return result
-
     }()
 
     let canvasSize: CGSize
@@ -117,7 +121,6 @@ public final class ImageRenderer {
             drawer.draw(in: cgContext, canvasSize: canvasSize)
           }
       }
-      
     }
     
     return image

--- a/Sources/PixelEngine/Engine/ImageRenderer.swift
+++ b/Sources/PixelEngine/Engine/ImageRenderer.swift
@@ -106,24 +106,23 @@ public final class ImageRenderer {
     let image = autoreleasepool { () -> UIImage in
       
       UIGraphicsImageRenderer.init(size: rotatedCanvas.size, format: format)
-        .image { c in
-          
-          let cgContext = UIGraphicsGetCurrentContext()!
-          
+        .image { context in
+                             
           let cgImage = cicontext.createCGImage(resultImage, from: resultImage.extent, format: .RGBA8, colorSpace: resultImage.colorSpace ?? CGColorSpaceCreateDeviceRGB())!
           
-          cgContext.saveGState()
-          cgContext.translateBy(x: rotatedCanvas.size.width/2, y: rotatedCanvas.size.height/2)
-          cgContext.rotate(by: CGFloat(edit.angle))
-          cgContext.scaleBy(x: 1, y: -1)
-
-          let rect =  CGRect(x: -canvasSize.width/2, y: -canvasSize.height/2, width: canvasSize.width, height: canvasSize.height)
-          cgContext.draw(cgImage, in: rect)
+          context.cgContext.saveGState()
           
-          cgContext.restoreGState()
+          context.cgContext.translateBy(x: rotatedCanvas.size.width/2, y: rotatedCanvas.size.height/2)
+          context.cgContext.rotate(by: CGFloat(edit.angle))
+          context.cgContext.scaleBy(x: 1, y: -1)
+
+          let rect = CGRect(x: -canvasSize.width/2, y: -canvasSize.height/2, width: canvasSize.width, height: canvasSize.height)
+          context.cgContext.draw(cgImage, in: rect)
+          
+          context.cgContext.restoreGState()
           
           self.edit.drawer.forEach { drawer in
-            drawer.draw(in: cgContext, canvasSize: canvasSize)
+            drawer.draw(in: context.cgContext, canvasSize: canvasSize)
           }
       }
     }

--- a/Sources/PixelEngine/Engine/ImageRenderer.swift
+++ b/Sources/PixelEngine/Engine/ImageRenderer.swift
@@ -117,7 +117,7 @@ public final class ImageRenderer {
           cgContext.rotate(by: CGFloat(edit.angle))
           cgContext.scaleBy(x: 1, y: -1)
 
-          let rect =  CGRect(x: -rotatedCanvas.size.width/2, y: -rotatedCanvas.size.height/2, width: rotatedCanvas.size.width, height: rotatedCanvas.size.height)
+          let rect =  CGRect(x: -canvasSize.width/2, y: -canvasSize.height/2, width: canvasSize.width, height: canvasSize.height)
           cgContext.draw(cgImage, in: rect)
           
           cgContext.restoreGState()


### PR DESCRIPTION
![rotation](https://user-images.githubusercontent.com/6825362/76746046-36408f00-67ba-11ea-82a7-c9bbbf05165c.gif)

I am currently working on adding a rotation feature.

I don't think I did an amazing job with this, so I am looking for your help/feedback cc @ntnmrndn  @muukii @JohnEstropia 

**Done:**
- [x] The rotation is happening on the UIImageView and the angle is saved in the EditingStack property

**Todo:**
- [ ] Inside the `ImageRenderer.swift` is where happens the final changes to the original image. 
Where do you think is the best place to rotate the image and why?

**To improve:**
- [ ] I hardcoded the four different rotation of the UIImageView inside `allRotations`, but it's probably not the optional solution for that.